### PR TITLE
NVIDIA 470.74 Linux Driver

### DIFF
--- a/sgfxi
+++ b/sgfxi
@@ -3,8 +3,8 @@
 ####  Script Name: simple/system graphics installer: sgfxi
 ####  Debian Sid, Testing, and Stable graphic driver install.
 ####  Note: Ubuntu support varies. Arch/Fedora support anemic
-####  version: 4.26.60
-####  Date: 2021-08-30
+####  version: 4.26.61
+####  Date: 2021-09-23
 ########################################################################
 ####  Copyright (C) Harald Hope 2007-2021
 ####  Code contributions copyright: Latino 2008
@@ -271,7 +271,7 @@ OTHER_VERSIONS=''
 # http://us.download.nvidia.com/XFree86/Linux-x86/latest.txt
 # https://raw.githubusercontent.com/aaronp24/nvidia-versions/master/nvidia-versions.txt
 # 304.88, 310.44, 313.30 fix buffer overflow issue
-NV_VERSIONS='470.63.01:390.144:340.108:304.137:173.14.39:96.43.23:71.86.15'
+NV_VERSIONS='470.74:390.144:340.108:304.137:173.14.39:96.43.23:71.86.15'
 # in case the new ones don't support 3.10 kernel
 # NV_VERSIONS='325.15:304.88:173.14.37:96.43.23:71.86.15'
 NV_DEFAULT=$( echo $NV_VERSIONS | cut -d ':' -f 1 ) # >= 6xxx
@@ -298,7 +298,7 @@ NV_LEGACY_BETA_6=$( echo $NV_VERSIONS_BETA | cut -d ':' -f 2 ) # gt4xx/gt5xx/gt6
 NV_QUAD=$NV_DEFAULT # no more individual quad drivers
 # this is what gets tested, and any other beta drivers remaining
 NV_BETA="$NV_VERSIONS_BETA::::"
-# stable primary: 460.56 460.67 460.73.01 465.27 465.31 470.57.02 470.63.01
+# stable primary: 460.56 460.67 460.73.01 465.27 465.31 470.57.02 470.63.01 470.74
 # stable primary: 450.57 450.66 450.80.02 455.28 455.38 455.45.01 460.32.03 460.39
 # stable primary: 430.40 435.21 440.31 440.36 440.44 440.59 440.64 440.82 440.100
 # stable primary: 415.18 415.23 415.27 418.43 418.56 418.74 430.14 430.26 430.34 
@@ -312,6 +312,7 @@ NV_BETA="$NV_VERSIONS_BETA::::"
 # stable primary: 280.13 285.05.09 290.10 295.20 295.33 295.40
 # stable primary: 275.09.07 275.19 275.21 
 # beta requested by users: 396.54.09 not available for download
+# lt stable primary: 470.74
 # lt stable primary: 460.32.03 460.39 460.56 460.67 460.80 460.84 470.57.02 470.63.01
 # lt stable primary: 430.40 440.31 440.36 440.44 440.59 440.64 440.82 450.66 450.80.02
 # lt stable primary: 390.87 390.116 390.129 410.66 410.73 410.78 430.14 430.26 430.34 
@@ -349,7 +350,7 @@ NV_BETA="$NV_VERSIONS_BETA::::"
 
 # beta/others: 310.14 313.09 319.12 355.06
 ## note: no earlier 302 or 295 drivers offered because they had a security hole
-NV_OTHERS=$NV_OTHERS'470.63.01:470.57.02:465.31:465.27:'
+NV_OTHERS=$NV_OTHERS'470.74:470.63.01:470.57.02:465.31:465.27:'
 NV_OTHERS=$NV_OTHERS'460.84:460.80:455.45.01:455.38:450.80.02:'
 NV_OTHERS=$NV_OTHERS'440.100:435.21:430.40:418.74:415.27:410.78:396.54:'
 # legacy 6


### PR DESCRIPTION
- Fixed a bug that could cause GPU applications to exit when resuming
from suspend.
- Fixed a regression which resulted in very-high system memory usage for
Direct3D 12 games when run through vkd3d-proton.
- Added an application profile to disable FXAA for Firefox to prevent
visual corruption.
- Fixed a Vulkan performance regression that affected rFactor2.
- Fixed a bug that could cause the /proc/driver/nvidia/suspend power
management interface to fail to preserve and restore video memory
allocations when the NVreg_TemporaryFilePath module parameter for
nvidia.ko specified an invalid path.
- Fixed a bug that caused nvidia-drm.ko to crash when loading with DRM
KMS enabled (modeset=1) on Linux v5.14.