### PR TITLE
NVIDIA 510.54 Linux Driver

### DIFF
--- a/sgfxi
+++ b/sgfxi
@@ -3,8 +3,8 @@
 ####  Script Name: simple/system graphics installer: sgfxi
 ####  Debian Sid, Testing, and Stable graphic driver install.
 ####  Note: Ubuntu support varies. Arch/Fedora support anemic
-####  version: 4.26.66
-####  Date: 2022-02-10
+####  version: 4.26.67
+####  Date: 2022-02-23
 ########################################################################
 ####  Copyright (C) Harald Hope 2007-2021
 ####  Code contributions copyright: Latino 2008
@@ -271,7 +271,7 @@ OTHER_VERSIONS=''
 # http://us.download.nvidia.com/XFree86/Linux-x86/latest.txt
 # https://raw.githubusercontent.com/aaronp24/nvidia-versions/master/nvidia-versions.txt
 # 304.88, 310.44, 313.30 fix buffer overflow issue
-NV_VERSIONS='510.47.03:390.144:340.108:304.137:173.14.39:96.43.23:71.86.15'
+NV_VERSIONS='510.54:390.144:340.108:304.137:173.14.39:96.43.23:71.86.15'
 # in case the new ones don't support 3.10 kernel
 # NV_VERSIONS='325.15:304.88:173.14.37:96.43.23:71.86.15'
 NV_DEFAULT=$( echo $NV_VERSIONS | cut -d ':' -f 1 ) # >= 6xxx
@@ -299,7 +299,7 @@ NV_QUAD=$NV_DEFAULT # no more individual quad drivers
 # this is what gets tested, and any other beta drivers remaining
 # Note: 495.44 and newer requires kernel 3.10 or newer
 NV_BETA="$NV_VERSIONS_BETA::::"
-# stable primary: 470.86 470.103.01 495.44 495.46 510.47.03
+# stable primary: 470.86 470.103.01 495.44 495.46 510.47.03 510.54
 # stable primary: 460.56 460.67 460.73.01 465.27 465.31 470.57.02 470.63.01 470.74
 # stable primary: 450.57 450.66 450.80.02 455.28 455.38 455.45.01 460.32.03 460.39
 # stable primary: 430.40 435.21 440.31 440.36 440.44 440.59 440.64 440.82 440.100
@@ -356,7 +356,7 @@ NV_BETA="$NV_VERSIONS_BETA::::"
 
 # beta/others: 310.14 313.09 319.12 355.06
 ## note: no earlier 302 or 295 drivers offered because they had a security hole
-NV_OTHERS=$NV_OTHERS'510.47.03:'
+NV_OTHERS=$NV_OTHERS'510.54:510.47.03:'
 NV_OTHERS=$NV_OTHERS'495.46:495.44:470.103.01:470.86:470.74:465.31:465.27:'
 NV_OTHERS=$NV_OTHERS'460.84:460.80:455.45.01:455.38:450.80.02:'
 NV_OTHERS=$NV_OTHERS'440.100:435.21:430.40:418.74:415.27:410.78:396.54:'


### PR DESCRIPTION
- Fixed a bug that could cause GPU exceptions when minimizing a
fullscreen Vulkan application on certain desktops, such as Plasma.