### PR TITLE
NVIDIA 510.68.02

### DIFF
--- a/sgfxi
+++ b/sgfxi
@@ -3,8 +3,8 @@
 ####  Script Name: simple/system graphics installer: sgfxi
 ####  Debian Sid, Testing, and Stable graphic driver install.
 ####  Note: Ubuntu support varies. Arch/Fedora support anemic
-####  version: 4.26.70
-####  Date: 2022-03-29
+####  version: 4.26.71
+####  Date: 2022-04-28
 ########################################################################
 ####  Copyright (C) Harald Hope 2007-2021
 ####  Code contributions copyright: Latino 2008
@@ -276,7 +276,7 @@ OTHER_VERSIONS=''
 # Replace latest driver number in above url to get the current legacy product ID list
 # if legacy list page is not updated, which sometimes happens.
 # 304.88, 310.44, 313.30 fix buffer overflow issue
-NV_VERSIONS='510.60.02:470.103.01:390.144:340.108:304.137:173.14.39:96.43.23:71.86.15'
+NV_VERSIONS='510.68.02:470.103.01:390.144:340.108:304.137:173.14.39:96.43.23:71.86.15'
 # assign to each level
 NV_DEFAULT=$( echo $NV_VERSIONS | cut -d ':' -f 1 ) # >= 6xxx
 NV_LEGACY_1=$( echo $NV_VERSIONS | cut -d ':' -f 8 ) # old, tnt etc
@@ -307,7 +307,7 @@ NV_QUAD=$NV_DEFAULT # no more individual quad drivers
 NV_BETA="$NV_VERSIONS_BETA"
 # Note: 495.44 and newer requires kernel 3.10 or newer
 # stable primary: 
-# stable primary: 470.86 495.44 495.46 510.47.03 510.54 510.60.02
+# stable primary: 470.86 495.44 495.46 510.47.03 510.54 510.60.02 510.68.02
 # stable primary: 460.56 460.67 460.73.01 465.27 465.31 470.57.02 470.63.01 470.74
 # stable primary: 450.57 450.66 450.80.02 455.28 455.38 455.45.01 460.32.03 460.39
 # stable primary: 430.40 435.21 440.31 440.36 440.44 440.59 440.64 440.82 440.100
@@ -322,7 +322,7 @@ NV_BETA="$NV_VERSIONS_BETA"
 # stable primary: 280.13 285.05.09 290.10 295.20 295.33 295.40
 # stable primary: 275.09.07 275.19 275.21 
 # beta requested by users: 396.54.09 not available for download
-# lts primary: 470.74 470.86 470.103.01 495.44 495.46 510.60.02
+# lts primary: 470.74 470.86 470.103.01 495.44 495.46 510.60.02 510.68.02
 # lts primary: 460.32.03 460.39 460.56 460.67 460.80 460.84 470.57.02 470.63.01
 # lts primary: 430.40 440.31 440.36 440.44 440.59 440.64 440.82 450.66 450.80.02
 # lts primary: 390.87 390.116 390.129 410.66 410.73 410.78 430.14 430.26 430.34 
@@ -368,7 +368,7 @@ NV_BETA="$NV_VERSIONS_BETA"
 # beta/others: 310.14 313.09 319.12 355.06
 ## note: no earlier 302 or 295 drivers offered because they had a security hole
 NV_OTHERS=$NV_OTHERS''
-NV_OTHERS=$NV_OTHERS'495.46:495.44:465.31:465.27:510.60.02:510.54:510.47.03:'
+NV_OTHERS=$NV_OTHERS'495.46:495.44:465.31:465.27:510.68.02:510.60.02:510.54:510.47.03:'
 NV_OTHERS=$NV_OTHERS'460.84:460.80:455.45.01:455.38:450.80.02:'
 NV_OTHERS=$NV_OTHERS'440.100:435.21:430.40:418.74:415.27:410.78:396.54:'
 # legacy 7


### PR DESCRIPTION
- Comaptible with Kernel 5.18 (tested with 5.18-rc4)
- Fixed an issue where NvFBC was requesting Vulkan 1.0 while using
Vulkan 1.1 core features. This caused NvFBC to fail to initialize with
Vulkan loader versions 1.3.204 or newer.